### PR TITLE
gcp: moving scheduler api to cloud-setup

### DIFF
--- a/apis.tf
+++ b/apis.tf
@@ -1,4 +1,0 @@
-resource "google_project_service" "cloud_scheduler" {
-  project = var.google_project
-  service = "cloudscheduler.googleapis.com"
-}

--- a/jobs_pubsub.tf
+++ b/jobs_pubsub.tf
@@ -14,6 +14,4 @@ resource "google_cloud_scheduler_job" "job" {
     data       = base64encode(lookup(element(values(var.jobs_pubsub), count.index), "message"))
     attributes = lookup(element(values(var.jobs_pubsub), count.index), "attributes")
   }
-
-  depends_on = [google_project_service.cloud_scheduler]
 }


### PR DESCRIPTION
<!--
  Does this PR reference or resolve Issue?
    Related: #000, #000
    Resolves: #000, #000
-->
Related: https://github.com/bulderbank/cloud-setup/pull/1248/


This module implements the Cloud Scheduler API. When a call to this module was removed from `cloud-setup`, the api got disabled for the firebase projects:


eg. https://app.circleci.com/pipelines/github/bulderbank/cloud-setup/4270/workflows/96bc863a-cb15-4618-b861-9994978aaaf3/jobs/17429

Removing the api enabler from this module, and putting it in `cloud-setup` to avoid future issues.
